### PR TITLE
Changed autogenerated docs to javadoc documentation

### DIFF
--- a/.utils/publish-docs.sh
+++ b/.utils/publish-docs.sh
@@ -6,8 +6,8 @@ git clone --quiet https://${GH_TOKEN}@github.com/NiewidzialnyCzlowiek/text-trans
 
 # Commit and Push the Changes
 cd text-transformer
-mvn site
-cp -Rf ./target/site/** ./docs
+mvn javadoc:javadoc
+cp -Rf ./target/site/apidocs/** ./docs
 rm -r ./target
 git add ./docs/**
 git commit -m "Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to /docs directory"

--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,15 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.7.1</version>
-            </plugin>
         </plugins>
     </build>
-
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>


### PR DESCRIPTION
I removed unnecessary site plugin and added javadoc plugin instead. I also modified the bash script that travis uses to publish the documentation.